### PR TITLE
Add support for updating Major/Minor git tags on release

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,46 @@
+---
+name: Build Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: read
+  issues: write
+
+defaults:
+  run:
+    # Error handling and pipefile must be explicitly set via the default shell
+    #   https://github.com/actions/runner/issues/353#issuecomment-1067227665
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+jobs:
+
+  update-tags:
+    name: Update Major/Minor Tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Fetch the tags
+        run: git fetch --force --tags
+
+      - name: Force update the major tag
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          VERSION=${TAG#v}
+          MAJOR=${VERSION%%.*}
+          git tag v${MAJOR} ${TAG} -f
+          git push origin refs/tags/v${MAJOR} -f
+
+      - name: Force update the major/minor tag
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          VERSION=${TAG#v}
+          MAJOR_MINOR=${VERSION%.*}
+          git tag v${MAJOR_MINOR} ${TAG} -f
+          git push origin refs/tags/v${MAJOR_MINOR} -f


### PR DESCRIPTION
Add support for updating the SemVer Major/Minor git tags on each release to provide support for `v{x}` and `v{x.y}` references for releases when using this GitHub Action.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
